### PR TITLE
:sparkles: Filter social network inputs to remove potential @

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -96,6 +96,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Slashgear",
+      "name": "Antoine Caron",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/6263857?v=4",
+      "profile": "http://slashgear.github.io/",
+      "contributions": [
+        "code",
+        "test",
+        "ideas"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Feel free to check [issues page](https://github.com/kefranabg/readme-md-generato
   <tr>
     <td align="center"><a href="https://github.com/hgb123"><img src="https://avatars0.githubusercontent.com/u/18468577?v=4" width="75px;" alt="Bao Ho"/><br /><sub><b>Bao Ho</b></sub></a><br /><a href="https://github.com/kefranabg/readme-md-generator/commits?author=hgb123" title="Code">💻</a> <a href="https://github.com/kefranabg/readme-md-generator/commits?author=hgb123" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/zizizi17"><img src="https://avatars0.githubusercontent.com/u/10571073?v=4" width="75px;" alt="Sasha Semanyuk"/><br /><sub><b>Sasha Semanyuk</b></sub></a><br /><a href="https://github.com/kefranabg/readme-md-generator/commits?author=zizizi17" title="Code">💻</a></td>
+    <td align="center"><a href="http://slashgear.github.io/"><img src="https://avatars0.githubusercontent.com/u/6263857?v=4" width="75px;" alt="Antoine Caron"/><br /><sub><b>Antoine Caron</b></sub></a><br /><a href="https://github.com/kefranabg/readme-md-generator/commits?author=Slashgear" title="Code">💻</a> <a href="https://github.com/kefranabg/readme-md-generator/commits?author=Slashgear" title="Tests">⚠️</a> <a href="#ideas-Slashgear" title="Ideas, Planning, & Feedback">🤔</a></td>
   </tr>
 </table>
 

--- a/src/questions/author-github.js
+++ b/src/questions/author-github.js
@@ -5,5 +5,5 @@ module.exports = projectInfos => ({
   message: '👤  Github username (use empty value to skip)',
   name: 'authorGithubUsername',
   default: projectInfos.githubUsername,
-  transformer: cleanSocialNetworkUsername
+  filter: cleanSocialNetworkUsername
 })

--- a/src/questions/author-github.js
+++ b/src/questions/author-github.js
@@ -1,7 +1,9 @@
+const { cleanSocialNetworkUsername } = require('../utils');
+
 module.exports = projectInfos => ({
   type: 'input',
   message: '👤  Github username (use empty value to skip)',
   name: 'authorGithubUsername',
   default: projectInfos.githubUsername,
-  transform: input => input.replace(/^@/, '')
+  transform: cleanSocialNetworkUsername
 })

--- a/src/questions/author-github.js
+++ b/src/questions/author-github.js
@@ -2,5 +2,6 @@ module.exports = projectInfos => ({
   type: 'input',
   message: '👤  Github username (use empty value to skip)',
   name: 'authorGithubUsername',
-  default: projectInfos.githubUsername
+  default: projectInfos.githubUsername,
+  transform: input => input.replace(/^@/, '')
 })

--- a/src/questions/author-github.js
+++ b/src/questions/author-github.js
@@ -1,9 +1,9 @@
-const { cleanSocialNetworkUsername } = require('../utils');
+const { cleanSocialNetworkUsername } = require('../utils')
 
 module.exports = projectInfos => ({
   type: 'input',
   message: '👤  Github username (use empty value to skip)',
   name: 'authorGithubUsername',
   default: projectInfos.githubUsername,
-  transform: cleanSocialNetworkUsername
+  transformer: cleanSocialNetworkUsername
 })

--- a/src/questions/author-github.spec.js
+++ b/src/questions/author-github.spec.js
@@ -12,7 +12,7 @@ describe('askAuthorGithub', () => {
       message: '👤  Github username (use empty value to skip)',
       name: 'authorGithubUsername',
       default: githubUsername,
-      transform: expect.any(Function)
+      transformer: expect.any(Function)
     })
   })
 })

--- a/src/questions/author-github.spec.js
+++ b/src/questions/author-github.spec.js
@@ -11,7 +11,8 @@ describe('askAuthorGithub', () => {
       type: 'input',
       message: '👤  Github username (use empty value to skip)',
       name: 'authorGithubUsername',
-      default: githubUsername
+      default: githubUsername,
+      transform: expect.any(Function)
     })
   })
 })

--- a/src/questions/author-github.spec.js
+++ b/src/questions/author-github.spec.js
@@ -12,7 +12,7 @@ describe('askAuthorGithub', () => {
       message: '👤  Github username (use empty value to skip)',
       name: 'authorGithubUsername',
       default: githubUsername,
-      transformer: expect.any(Function)
+      filter: expect.any(Function)
     })
   })
 })

--- a/src/questions/author-twitter.js
+++ b/src/questions/author-twitter.js
@@ -1,5 +1,6 @@
 module.exports = () => ({
   type: 'input',
   message: '🐦  Twitter username (use empty value to skip)',
-  name: 'authorTwitterUsername'
+  name: 'authorTwitterUsername',
+  transform: input => input.replace(/^@/, '')
 })

--- a/src/questions/author-twitter.js
+++ b/src/questions/author-twitter.js
@@ -1,6 +1,8 @@
+const { cleanSocialNetworkUsername } = require('../utils');
+
 module.exports = () => ({
   type: 'input',
   message: '🐦  Twitter username (use empty value to skip)',
   name: 'authorTwitterUsername',
-  transform: input => input.replace(/^@/, '')
+  transform: cleanSocialNetworkUsername
 })

--- a/src/questions/author-twitter.js
+++ b/src/questions/author-twitter.js
@@ -1,8 +1,8 @@
-const { cleanSocialNetworkUsername } = require('../utils');
+const { cleanSocialNetworkUsername } = require('../utils')
 
 module.exports = () => ({
   type: 'input',
   message: '🐦  Twitter username (use empty value to skip)',
   name: 'authorTwitterUsername',
-  transform: cleanSocialNetworkUsername
+  transformer: cleanSocialNetworkUsername
 })

--- a/src/questions/author-twitter.js
+++ b/src/questions/author-twitter.js
@@ -4,5 +4,5 @@ module.exports = () => ({
   type: 'input',
   message: '🐦  Twitter username (use empty value to skip)',
   name: 'authorTwitterUsername',
-  transformer: cleanSocialNetworkUsername
+  filter: cleanSocialNetworkUsername
 })

--- a/src/questions/author-twitter.spec.js
+++ b/src/questions/author-twitter.spec.js
@@ -7,7 +7,8 @@ describe('askAuthorTwitter', () => {
     expect(result).toEqual({
       type: 'input',
       message: '🐦  Twitter username (use empty value to skip)',
-      name: 'authorTwitterUsername'
+      name: 'authorTwitterUsername',
+      transform: expect.any(Function)
     })
   })
 })

--- a/src/questions/author-twitter.spec.js
+++ b/src/questions/author-twitter.spec.js
@@ -8,7 +8,7 @@ describe('askAuthorTwitter', () => {
       type: 'input',
       message: '🐦  Twitter username (use empty value to skip)',
       name: 'authorTwitterUsername',
-      transformer: expect.any(Function)
+      filter: expect.any(Function)
     })
   })
 })

--- a/src/questions/author-twitter.spec.js
+++ b/src/questions/author-twitter.spec.js
@@ -8,7 +8,7 @@ describe('askAuthorTwitter', () => {
       type: 'input',
       message: '🐦  Twitter username (use empty value to skip)',
       name: 'authorTwitterUsername',
-      transform: expect.any(Function)
+      transformer: expect.any(Function)
     })
   })
 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,6 +96,14 @@ const getDefaultAnswers = questions =>
     {}
   )
 
+/**
+ * Clean social network username by removing the @ prefix
+ *
+ * @param input social network username input
+ * @returns {*} input without the prefix
+ */
+const cleanSocialNetworkUsername = input => input.replace(/^@/, '')
+
 module.exports = {
   getPackageJson,
   showEndMessage,
@@ -103,5 +111,6 @@ module.exports = {
   END_MSG,
   BOXEN_CONFIG,
   getDefaultAnswers,
-  getDefaultAnswer
+  getDefaultAnswer,
+  cleanSocialNetworkUsername
 }

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -202,7 +202,7 @@ describe('utils', () => {
       expect(cleanSocialNetworkUsername('@Slashgear_')).toEqual('Slashgear_')
     })
 
-    it('should return the same string when string in not prefixed', () => {
+    it('should return the same string when string is not prefixed', () => {
       expect(cleanSocialNetworkUsername('Slashgear_')).toEqual('Slashgear_')
     })
   })

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -14,7 +14,8 @@ const {
   END_MSG,
   BOXEN_CONFIG,
   getDefaultAnswer,
-  getDefaultAnswers
+  getDefaultAnswers,
+  cleanSocialNetworkUsername
 } = require('./utils')
 
 jest.mock('load-json-file')
@@ -195,4 +196,17 @@ describe('utils', () => {
       })
     })
   })
+
+  describe('cleanSocialNetworkUsername', () => {
+
+    it('should remove prefixed @', () => {
+      expect(cleanSocialNetworkUsername('@Slashgear_')).toEqual('Slashgear_')
+    })
+
+
+    it('should return the same string when string in not prefixed', () => {
+      expect(cleanSocialNetworkUsername('Slashgear_')).toEqual('Slashgear_')
+    })
+  })
+
 })

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -198,7 +198,6 @@ describe('utils', () => {
   })
 
   describe('cleanSocialNetworkUsername', () => {
-
     it('should remove prefixed @', () => {
       expect(cleanSocialNetworkUsername('@Slashgear_')).toEqual('Slashgear_')
     })
@@ -208,5 +207,4 @@ describe('utils', () => {
       expect(cleanSocialNetworkUsername('Slashgear_')).toEqual('Slashgear_')
     })
   })
-
 })

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -202,7 +202,6 @@ describe('utils', () => {
       expect(cleanSocialNetworkUsername('@Slashgear_')).toEqual('Slashgear_')
     })
 
-
     it('should return the same string when string in not prefixed', () => {
       expect(cleanSocialNetworkUsername('Slashgear_')).toEqual('Slashgear_')
     })


### PR DESCRIPTION
Fix #92 

In order to help user, it will remove the prefixed `@` if the user write it in the prompt.
- update unit tests
