### PR TITLE
:sparkles: dynamic license badge

### DIFF
--- a/src/__snapshots__/readme.spec.js.snap
+++ b/src/__snapshots__/readme.spec.js.snap
@@ -15,7 +15,7 @@ exports[`readme buildReadmeContent should return readme default template content
     <img alt=\\"Maintenance\\" src=\\"https://img.shields.io/badge/Maintained%3F-yes-green.svg\\" />
   </a>
   <a href=\\"https://github.com/kefranabg/readme-md-generator/blob/master/LICENSE\\" target=\\"_blank\\">
-    <img alt=\\"License: MIT\\" src=\\"https://img.shields.io/badge/License-MIT-yellow.svg\\" />
+    <img alt=\\"License: MIT\\" src=\\"https://img.shields.io/github/license/kefranabg/readme-md-generator\\" />
   </a>
   <a href=\\"https://twitter.com/FranckAbgrall\\" target=\\"_blank\\">
     <img alt=\\"Twitter: FranckAbgrall\\" src=\\"https://img.shields.io/twitter/follow/FranckAbgrall.svg?style=social\\" />
@@ -84,7 +84,7 @@ exports[`readme buildReadmeContent should return readme default template no html
 ![Prerequisite](https://img.shields.io/badge/node-%3E%3D%209.3.0-blue.svg)
 [![Documentation](https://img.shields.io/badge/documentation-yes-brightgreen.svg)](https://github.com/kefranabg/readme-md-generator#readme)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/kefranabg/readme-md-generator/graphs/commit-activity)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/kefranabg/readme-md-generator/blob/master/LICENSE)
+[![License: MIT](https://img.shields.io/github/license/kefranabg/readme-md-generator)](https://github.com/kefranabg/readme-md-generator/blob/master/LICENSE)
 [![Twitter: FranckAbgrall](https://img.shields.io/twitter/follow/FranckAbgrall.svg?style=social)](https://twitter.com/FranckAbgrall)
 
 > Generates beautiful README files from git config &amp; package.json infos

--- a/templates/default-no-html.md
+++ b/templates/default-no-html.md
@@ -16,7 +16,10 @@
 <% if (isGithubRepos) { -%>
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](<%= repositoryUrl %>/graphs/commit-activity)
 <% } -%>
-<% if (licenseName && licenseUrl) { -%>
+<% if (isGithubRepos && licenseName && licenseUrl) { -%>
+[![License: <%= licenseName %>](https://img.shields.io/github/license/<%= authorGithubUsername %>/<%= projectName %>)](<%= licenseUrl %>)
+<% } -%>
+<% if (!isGithubRepos && licenseName && licenseUrl) { -%>
 [![License: <%= licenseName %>](https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg)](<%= licenseUrl %>)
 <% } -%>
 <% if (authorTwitterUsername) { -%>

--- a/templates/default.md
+++ b/templates/default.md
@@ -23,7 +23,12 @@
     <img alt="Maintenance" src="https://img.shields.io/badge/Maintained%3F-yes-green.svg" />
   </a>
 <% } -%>
-<% if (licenseName && licenseUrl) { -%>
+<% if (isGithubRepos && licenseName && licenseUrl) { -%>
+  <a href="<%= licenseUrl %>" target="_blank">
+    <img alt="License: <%= licenseName %>" src="https://img.shields.io/github/license/<%= authorGithubUsername %>/<%= projectName %>" />
+  </a>
+<% } -%>
+<% if (!isGithubRepos && licenseName && licenseUrl) { -%>
   <a href="<%= licenseUrl %>" target="_blank">
     <img alt="License: <%= licenseName %>" src="https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg" />
   </a>


### PR DESCRIPTION
Add a dynamic badge for license.
If the projet is on Github, the badge will reflect the license of the Github project. 
Note that it could mismatch answers from the user.

fix #131 