### PR TITLE
fixes #134: Display license badge even when there is no license url

### DIFF
--- a/templates/default-no-html.md
+++ b/templates/default-no-html.md
@@ -22,6 +22,9 @@
 <% if (!isGithubRepos && licenseName && licenseUrl) { -%>
 [![License: <%= licenseName %>](https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg)](<%= licenseUrl %>)
 <% } -%>
+<% if (licenseName && !licenseUrl) { -%>
+[![License: <%= licenseName %>](https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg)](#)
+<% } -%>
 <% if (authorTwitterUsername) { -%>
 [![Twitter: <%= authorTwitterUsername %>](https://img.shields.io/twitter/follow/<%= authorTwitterUsername %>.svg?style=social)](https://twitter.com/<%= authorTwitterUsername %>)
 <% } -%>

--- a/templates/default-no-html.md
+++ b/templates/default-no-html.md
@@ -16,14 +16,8 @@
 <% if (isGithubRepos) { -%>
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](<%= repositoryUrl %>/graphs/commit-activity)
 <% } -%>
-<% if (isGithubRepos && licenseName && licenseUrl) { -%>
-[![License: <%= licenseName %>](https://img.shields.io/github/license/<%= authorGithubUsername %>/<%= projectName %>)](<%= licenseUrl %>)
-<% } -%>
-<% if (!isGithubRepos && licenseName && licenseUrl) { -%>
-[![License: <%= licenseName %>](https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg)](<%= licenseUrl %>)
-<% } -%>
-<% if (licenseName && !licenseUrl) { -%>
-[![License: <%= licenseName %>](https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg)](#)
+<% if (licenseName) { -%>
+[![License: <%= licenseName %>](https://img.shields.io/<%= isGithubRepos ? `github/license/${authorGithubUsername}/${projectName}` : `badge/License-${licenseName}-yellow.svg` %>)](<%= licenseUrl ? licenseUrl : '#' %>)
 <% } -%>
 <% if (authorTwitterUsername) { -%>
 [![Twitter: <%= authorTwitterUsername %>](https://img.shields.io/twitter/follow/<%= authorTwitterUsername %>.svg?style=social)](https://twitter.com/<%= authorTwitterUsername %>)

--- a/templates/default.md
+++ b/templates/default.md
@@ -33,6 +33,11 @@
     <img alt="License: <%= licenseName %>" src="https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg" />
   </a>
 <% } -%>
+<% if (licenseName && !licenseUrl) { -%>
+  <a href="#" target="_blank">
+    <img alt="License: <%= licenseName %>" src="https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg" />
+  </a>
+<% } -%>
 <% if (authorTwitterUsername) { -%>
   <a href="https://twitter.com/<%= authorTwitterUsername %>" target="_blank">
     <img alt="Twitter: <%= authorTwitterUsername %>" src="https://img.shields.io/twitter/follow/<%= authorTwitterUsername %>.svg?style=social" />

--- a/templates/default.md
+++ b/templates/default.md
@@ -23,19 +23,9 @@
     <img alt="Maintenance" src="https://img.shields.io/badge/Maintained%3F-yes-green.svg" />
   </a>
 <% } -%>
-<% if (isGithubRepos && licenseName && licenseUrl) { -%>
-  <a href="<%= licenseUrl %>" target="_blank">
-    <img alt="License: <%= licenseName %>" src="https://img.shields.io/github/license/<%= authorGithubUsername %>/<%= projectName %>" />
-  </a>
-<% } -%>
-<% if (!isGithubRepos && licenseName && licenseUrl) { -%>
-  <a href="<%= licenseUrl %>" target="_blank">
-    <img alt="License: <%= licenseName %>" src="https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg" />
-  </a>
-<% } -%>
-<% if (licenseName && !licenseUrl) { -%>
-  <a href="#" target="_blank">
-    <img alt="License: <%= licenseName %>" src="https://img.shields.io/badge/License-<%= licenseName %>-yellow.svg" />
+<% if (licenseName) { -%>
+  <a href="<%= licenseUrl ? licenseUrl : '#' %>" target="_blank">
+    <img alt="License: <%= licenseName %>" src="https://img.shields.io/<%= isGithubRepos ? `github/license/${authorGithubUsername}/${projectName}` : `badge/License-${licenseName}-yellow.svg` %>" />
   </a>
 <% } -%>
 <% if (authorTwitterUsername) { -%>


### PR DESCRIPTION
When there is a license name but no license URL, we will show the license badge with `href=#`.  

Example Image:

![image](https://user-images.githubusercontent.com/22813027/66030814-ce55ff00-e51f-11e9-85f2-fa2108ad783b.png)

I ran the tests and all tests are passing.

If it is not the desired fix, please let me know and I will update my PR accordingly.

Thank you.