### PR TITLE
:bug: Fix static badge generation when license name contains special characters

### DIFF
--- a/src/clean-context.js
+++ b/src/clean-context.js
@@ -1,6 +1,11 @@
+/**
+ * Clean answer context
+ *
+ * @param {Object} context
+ */
 module.exports = context => {
   // Why doing this?
-  // See https://shields.io/ 'Using dash "-" separator' section
+  // See https://github.com/kefranabg/readme-md-generator/pull/141
   const licenseName = context.licenseName
     .replace(/-/g, '--')
     .replace(/_/g, '__')

--- a/src/clean-context.js
+++ b/src/clean-context.js
@@ -1,0 +1,12 @@
+module.exports = context => {
+  // Why doing this?
+  // See https://shields.io/ 'Using dash "-" separator' section
+  const licenseName = context.licenseName
+    .replace(/-/g, '--')
+    .replace(/_/g, '__')
+
+  return {
+    ...context,
+    licenseName
+  }
+}

--- a/src/clean-context.spec.js
+++ b/src/clean-context.spec.js
@@ -1,0 +1,12 @@
+const cleanContext = require('./clean-context')
+
+describe('cleanContext', () => {
+  it('should replace licenseName - and _ characters by -- and __', () => {
+    const context = { licenseName: 'Apache-2_0' }
+    const cleanedContext = { licenseName: 'Apache--2__0' }
+
+    const result = cleanContext(context)
+
+    expect(result).toEqual(cleanedContext)
+  })
+})

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@ const readme = require('./readme')
 const infos = require('./project-infos')
 const utils = require('./utils')
 const askQuestions = require('./ask-questions')
+const cleanContext = require('./clean-context')
 
 /**
  * Main process:
@@ -9,8 +10,9 @@ const askQuestions = require('./ask-questions')
  * 2) Get README template path
  * 3) Gather project infos
  * 4) Ask user questions
- * 5) Build README content
- * 6) Create README.md file
+ * 5) Clean answer context
+ * 6) Build README content
+ * 7) Create README.md file
  *
  * @param {Object} args
  */
@@ -26,8 +28,9 @@ module.exports = async ({ customTemplatePath, useDefaultAnswers }) => {
     projectInformations,
     useDefaultAnswers
   )
+  const cleanedContext = cleanContext(answersContext)
   const readmeContent = await readme.buildReadmeContent(
-    answersContext,
+    cleanedContext,
     templatePath
   )
 

--- a/src/cli.spec.js
+++ b/src/cli.spec.js
@@ -4,6 +4,7 @@ const infos = require('./project-infos')
 const readme = require('./readme')
 const utils = require('./utils')
 const askQuestions = require('./ask-questions')
+const cleanContext = require('./clean-context')
 
 inquirer.prompt = jest.fn(items =>
   Promise.resolve(
@@ -16,6 +17,10 @@ inquirer.prompt = jest.fn(items =>
 
 jest.mock('./ask-questions', () =>
   jest.fn(() => Promise.resolve({ projectName: 'readme-md-generator' }))
+)
+
+jest.mock('./clean-context', () =>
+  jest.fn(() => ({ projectName: 'readme-md-generator-after-context-clean' }))
 )
 
 jest.mock('./questions', () => ({
@@ -56,6 +61,7 @@ describe('mainProcess', () => {
     await mainProcess({ customTemplatePath, useDefaultAnswers })
 
     expect(infos.getProjectInfos).not.toHaveBeenCalled()
+    expect(cleanContext).not.toHaveBeenCalled()
     expect(readme.buildReadmeContent).not.toHaveBeenCalled()
     expect(readme.getReadmeTemplatePath).not.toHaveBeenCalled()
     expect(readme.writeReadme).not.toHaveBeenCalled()
@@ -88,9 +94,12 @@ describe('mainProcess', () => {
       projectInformations,
       useDefaultAnswers
     )
+    expect(cleanContext).toHaveBeenNthCalledWith(1, {
+      projectName: 'readme-md-generator'
+    })
     expect(readme.buildReadmeContent).toHaveBeenNthCalledWith(
       1,
-      { projectName: 'readme-md-generator' },
+      { projectName: 'readme-md-generator-after-context-clean' },
       templatePath
     )
     expect(readme.writeReadme).toHaveBeenNthCalledWith(1, readmeContent)


### PR DESCRIPTION
Fix #141 

I am duplicating the characters - and _ as suggested on https://shields.io/. 
<img width="468" alt="Capture d’écran 2019-10-02 à 14 54 56" src="https://user-images.githubusercontent.com/1022393/66045776-aa48ec80-e524-11e9-82a1-288e26a5ab19.png">
I am eager of some refactoring tips to avoid the duplication.
