### PR TITLE
Change Product Description to type editor

### DIFF
--- a/src/questions/project-description.js
+++ b/src/questions/project-description.js
@@ -1,5 +1,5 @@
 module.exports = projectInfos => ({
-  type: 'input',
+  type: 'editor',
   message: '📄  Project description',
   name: 'projectDescription',
   default: projectInfos.description

--- a/src/questions/project-description.spec.js
+++ b/src/questions/project-description.spec.js
@@ -8,7 +8,7 @@ describe('askProjectDescription', () => {
     const result = askProjectDescription(projectInfos)
 
     expect(result).toEqual({
-      type: 'input',
+      type: 'editor',
       message: '📄  Project description',
       name: 'projectDescription',
       default: description


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Project Description can vary from paragraph to a single line. Type "input" doesn't allow you to add text using line breaks.

**Describe the solution you'd like**
Changing type to "Editor", opens up an editor to add as much text as you want and in any format you require. 

**Describe alternatives you've considered**
Making the client choose the type of description he requires and inquiring accordingly.

😊Great project, justifying the power of CLI.