### PR TITLE
:recycle: re-use prettier regexp across scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   },
   "scripts": {
     "lint": "eslint src",
-    "prettier:check": "prettier \"**/*.{js,md,json}\" --list-different",
-    "prettier:fix": "prettier \"**/*.{js,md,json}\" --write",
+    "prettier": "prettier \"**/*.{js,md,json}\"",
+    "prettier:check": "npm run prettier -- --check",
+    "prettier:fix": "npm run prettier -- --write",
     "start": "node src/index.js",
     "test": "jest",
     "test:ci": "jest --coverage && codecov"


### PR DESCRIPTION
This PR builds on #158 and makes both prettier scripts use the same regexp to match files. This makes sure that there is no desync between the two scripts.

Thanks for making readme-md-generator! 👍 