### PR TITLE
:sparkles: Ask author's linkedin username (fixes #170)

### DIFF
--- a/src/__snapshots__/readme.spec.js.snap
+++ b/src/__snapshots__/readme.spec.js.snap
@@ -58,6 +58,7 @@ npm run test
 * Website: https://www.franck-abgrall.me/
 * Twitter: [@FranckAbgrall](https://twitter.com/FranckAbgrall)
 * Github: [@kefranabg](https://github.com/kefranabg)
+* LinkedIn: [@franckabgrall](https://linkedin.com/in/franckabgrall)
 
 ## 🤝 Contributing
 
@@ -126,6 +127,7 @@ npm run test
 * Website: https://www.franck-abgrall.me/
 * Twitter: [@FranckAbgrall](https://twitter.com/FranckAbgrall)
 * Github: [@kefranabg](https://github.com/kefranabg)
+* LinkedIn: [@franckabgrall](https://linkedin.com/in/franckabgrall)
 
 ## 🤝 Contributing
 

--- a/src/questions/author-linkedin.js
+++ b/src/questions/author-linkedin.js
@@ -1,0 +1,8 @@
+const { cleanSocialNetworkUsername } = require('../utils')
+
+module.exports = () => ({
+  type: 'input',
+  message: '🕴  LinkedIn username (use empty value to skip)',
+  name: 'authorLinkedInUsername',
+  filter: cleanSocialNetworkUsername
+})

--- a/src/questions/author-linkedin.js
+++ b/src/questions/author-linkedin.js
@@ -2,7 +2,7 @@ const { cleanSocialNetworkUsername } = require('../utils')
 
 module.exports = () => ({
   type: 'input',
-  message: '🕴  LinkedIn username (use empty value to skip)',
+  message: '💼  LinkedIn username (use empty value to skip)',
   name: 'authorLinkedInUsername',
   filter: cleanSocialNetworkUsername
 })

--- a/src/questions/author-linkedin.spec.js
+++ b/src/questions/author-linkedin.spec.js
@@ -6,7 +6,7 @@ describe('askAuthorLinkedIn', () => {
 
     expect(result).toEqual({
       type: 'input',
-      message: '🕴  LinkedIn username (use empty value to skip)',
+      message: '💼  LinkedIn username (use empty value to skip)',
       name: 'authorLinkedInUsername',
       filter: expect.any(Function)
     })

--- a/src/questions/author-linkedin.spec.js
+++ b/src/questions/author-linkedin.spec.js
@@ -1,0 +1,14 @@
+const askAuthorLinkedIn = require('./author-linkedin')
+
+describe('askAuthorLinkedIn', () => {
+  it('should return correct question format', () => {
+    const result = askAuthorLinkedIn()
+
+    expect(result).toEqual({
+      type: 'input',
+      message: '🕴  LinkedIn username (use empty value to skip)',
+      name: 'authorLinkedInUsername',
+      filter: expect.any(Function)
+    })
+  })
+})

--- a/src/questions/index.js
+++ b/src/questions/index.js
@@ -10,6 +10,7 @@ module.exports = {
   askAuthorGithub: require('./author-github'),
   askAuthorWebsite: require('./author-website'),
   askAuthorTwitter: require('./author-twitter'),
+  askAuthorLinkedIn: require('./author-linkedin'),
   askAuthorPatreon: require('./author-patreon'),
   askProjectPrerequisites: require('./project-prerequisites'),
   askLicenseName: require('./license-name'),

--- a/src/questions/index.spec.js
+++ b/src/questions/index.spec.js
@@ -15,6 +15,7 @@ describe('questions', () => {
       'askAuthorGithub',
       'askAuthorWebsite',
       'askAuthorTwitter',
+      'askAuthorLinkedIn',
       'askAuthorPatreon',
       'askProjectPrerequisites',
       'askLicenseName',

--- a/src/readme.spec.js
+++ b/src/readme.spec.js
@@ -97,6 +97,7 @@ describe('readme', () => {
       authorWebsite: 'https://www.franck-abgrall.me/',
       authorGithubUsername: 'kefranabg',
       authorTwitterUsername: 'FranckAbgrall',
+      authorLinkedInUsername: 'franckabgrall',
       authorPatreonUsername: 'FranckAbgrall',
       licenseName: 'MIT',
       licenseUrl:

--- a/templates/default-no-html.md
+++ b/templates/default-no-html.md
@@ -81,6 +81,9 @@
 <% if (authorGithubUsername) { -%>
 * Github: [@<%= authorGithubUsername %>](https://github.com/<%= authorGithubUsername %>)
 <% } -%>
+<% if (authorLinkedInUsername) { -%>
+* LinkedIn: [@<%= authorLinkedInUsername %>](https://linkedin.com/in/<%= authorLinkedInUsername %>)
+<% } -%>
 <% } -%>
 <% if (contributingUrl) { -%>
 

--- a/templates/default.md
+++ b/templates/default.md
@@ -93,6 +93,9 @@
 <% if (authorGithubUsername) { -%>
 * Github: [@<%= authorGithubUsername %>](https://github.com/<%= authorGithubUsername %>)
 <% } -%>
+<% if (authorLinkedInUsername) { -%>
+* LinkedIn: [@<%= authorLinkedInUsername %>](https://linkedin.com/in/<%= authorLinkedInUsername %>)
+<% } -%>
 <% } -%>
 <% if (contributingUrl) { -%>
 


### PR DESCRIPTION
Hi! 

This PR fixes #170.

I was confused about the emoji for LinkedIn (shown while asking for username). I ended up going with  🕴instead of 👤 but I am not sure about it. What do you think about it? 

Let me know of any changes if required. 

Thank you.
