### PR TITLE
:bug: Execute default function to get default answer when -y flag is passed

### DIFF
--- a/src/ask-questions.js
+++ b/src/ask-questions.js
@@ -16,7 +16,7 @@ module.exports = async (projectInfos, useDefaultAnswers) => {
   )
 
   const answersContext = useDefaultAnswers
-    ? utils.getDefaultAnswers(questions)
+    ? await utils.getDefaultAnswers(questions)
     : await inquirer.prompt(questions)
 
   return {

--- a/src/utils.js
+++ b/src/utils.js
@@ -110,16 +110,15 @@ const isProjectAvailableOnNpm = projectName => {
  *
  * @param {Array} questions
  */
-const getDefaultAnswers = async questions => {
-  const answersContext = {}
-  for (const question of questions) {
-    answersContext[question.name] = await getDefaultAnswer(
-      question,
-      answersContext
-    )
-  }
-  return answersContext
-}
+const getDefaultAnswers = questions =>
+  questions.reduce(async (answersContextProm, question) => {
+    const answersContext = await answersContextProm
+
+    return {
+      ...answersContext,
+      [question.name]: await getDefaultAnswer(question, answersContext)
+    }
+  }, Promise.resolve({}))
 
 /**
  * Clean social network username by removing the @ prefix

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,12 +73,14 @@ const getPackageJson = async () => {
  *
  * @param {Object} question
  */
-const getDefaultAnswer = (question, answersContext) => {
+const getDefaultAnswer = async (question, answersContext) => {
   if (question.when && !question.when(answersContext)) return undefined
 
   switch (question.type) {
     case 'input':
-      return question.default || ''
+      return typeof question.default === 'function'
+        ? question.default(answersContext)
+        : question.default || ''
     case 'checkbox':
       return question.choices
         .filter(choice => choice.checked)
@@ -108,14 +110,16 @@ const isProjectAvailableOnNpm = projectName => {
  *
  * @param {Array} questions
  */
-const getDefaultAnswers = questions =>
-  questions.reduce(
-    (answersContext, question) => ({
-      ...answersContext,
-      [question.name]: getDefaultAnswer(question, answersContext)
-    }),
-    {}
-  )
+const getDefaultAnswers = async questions => {
+  const answersContext = {}
+  for (const question of questions) {
+    answersContext[question.name] = await getDefaultAnswer(
+      question,
+      answersContext
+    )
+  }
+  return answersContext
+}
 
 /**
  * Clean social network username by removing the @ prefix

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -120,45 +120,45 @@ describe('utils', () => {
   })
 
   describe('getDefaultAnswer', () => {
-    it('should handle input prompts correctly', () => {
+    it('should handle input prompts correctly', async () => {
       const question = { type: 'input', default: 'default' }
-      const result = getDefaultAnswer(question)
+      const result = await getDefaultAnswer(question)
       expect(result).toEqual(question.default)
     })
 
-    it('should handle choices prompts correctly', () => {
+    it('should handle choices prompts correctly', async () => {
       const value = { name: 'name', value: 'value' }
       const question = {
         type: 'checkbox',
         choices: [{ value, checked: true }, { checked: false }]
       }
-      const result = getDefaultAnswer(question)
+      const result = await getDefaultAnswer(question)
 
       expect(result).toEqual([value])
     })
 
-    it('should return empty string for non-defaulted fields', () => {
+    it('should return empty string for non-defaulted fields', async () => {
       const question = { type: 'input' }
-      const result = getDefaultAnswer(question)
+      const result = await getDefaultAnswer(question)
 
       expect(result).toEqual('')
     })
 
-    it('should return undefined for invalid types', () => {
+    it('should return undefined for invalid types', async () => {
       const question = { type: 'invalid' }
-      const result = getDefaultAnswer(question)
+      const result = await getDefaultAnswer(question)
 
       expect(result).toEqual(undefined)
     })
 
-    it('should return undefined if when function is defined and return false', () => {
+    it('should return undefined if when function is defined and return false', async () => {
       const answersContext = {}
       const question = {
         type: 'input',
         when: ansewersContext => !isNil(ansewersContext.licenseUrl)
       }
 
-      const result = getDefaultAnswer(question, answersContext)
+      const result = await getDefaultAnswer(question, answersContext)
 
       expect(result).toEqual(undefined)
     })
@@ -177,7 +177,7 @@ describe('utils', () => {
       })
     })
 
-    it('should return correct value if when function is defined and return true', () => {
+    it('should return correct value if when function is defined and return true', async () => {
       const answersContext = { licenseUrl: 'licenseUrl' }
       const question = {
         type: 'input',
@@ -185,14 +185,14 @@ describe('utils', () => {
         when: ansewersContext => !isNil(ansewersContext.licenseUrl)
       }
 
-      const result = getDefaultAnswer(question, answersContext)
+      const result = await getDefaultAnswer(question, answersContext)
 
       expect(result).toEqual('default')
     })
   })
 
   describe('getDefaultAnswers', () => {
-    it('should return default answers from questions', () => {
+    it('should return default answers from questions', async () => {
       const questions = [
         {
           type: 'input',
@@ -206,7 +206,7 @@ describe('utils', () => {
         }
       ]
 
-      const result = getDefaultAnswers(questions)
+      const result = await getDefaultAnswers(questions)
 
       expect(result).toEqual({
         questionOne: 'answer 1',


### PR DESCRIPTION
Hi @kefranabg  👋

This PR fixes #180.

This is still a WIP. I need some help figuring this out. 

Since `author-website.js` default function returns a promise. We need to change `getDefaultAnswers` as well. The problem is that we need to pass `answersContext` to every question and this is why we can't iterate over all the questions asynchronously anymore.  I used `for of` loop to solve this issue but I feel there must be a better solution.  Can you help me with it? 
```
// utils.js

const getDefaultAnswers = async questions => {
  const answersContext = {}
  for (const question of questions) {
    answersContext[question.name] = await getDefaultAnswer(
      question,
      answersContext
    )
  }
  return answersContext
}
```
