### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "javascript"
+run = "npx readme-md-generator"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/frinyvonnick/gitmoji-changelog">
     <img src="https://img.shields.io/badge/changelog-gitmoji-brightgreen.svg" alt="gitmoji-changelog">
   </a>
+[![Run on Repl.it](https://repl.it/badge/github/kefranabg/readme-md-generator)](https://repl.it/github/kefranabg/readme-md-generator)
   <a href="https://twitter.com/FranckAbgrall">
     <img alt="Twitter: FranckAbgrall" src="https://img.shields.io/twitter/follow/FranckAbgrall.svg?style=social" target="_blank" />
   </a>


### PR DESCRIPTION
I really like this! I think it would be an excellent tool for beginners to encourage good documentation practice and so I configured it to be able to run in-browser through repl.it. I'm sure there would be ways to make it run smoother but this seems to work to cover the basics of creating a README.md file.
![Capture](https://user-images.githubusercontent.com/39810066/70563908-24b56e80-1b5d-11ea-9912-de123f06e2c1.PNG)
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/readme-md-generator).