### PR TITLE
Change test snapshot copyright year to 2021.

### DIFF
--- a/src/__snapshots__/readme.spec.js.snap
+++ b/src/__snapshots__/readme.spec.js.snap
@@ -74,7 +74,7 @@ Give a ⭐️ if this project helped you!
 
 ## 📝 License
 
-Copyright © 2019 [Franck Abgrall](https://github.com/kefranabg).<br />
+Copyright © 2021 [Franck Abgrall](https://github.com/kefranabg).<br />
 This project is [MIT](https://github.com/kefranabg/readme-md-generator/blob/master/LICENSE) licensed.
 
 ***
@@ -144,7 +144,7 @@ Give a ⭐️ if this project helped you!
 
 ## 📝 License
 
-Copyright © 2019 [Franck Abgrall](https://github.com/kefranabg).
+Copyright © 2021 [Franck Abgrall](https://github.com/kefranabg).
 
 This project is [MIT](https://github.com/kefranabg/readme-md-generator/blob/master/LICENSE) licensed.
 


### PR DESCRIPTION
Hello!

I wanted to play around with this project for a bit and noticed that some of the tests were failing right after cloning the project. After investigating, I found that 4 tests were failing because the Jest snapshot used to compare the generated readme in the test suite had an outdated year for copyright. I have bumped the year from 2019 to 2021 and now all tests pass.